### PR TITLE
Refactor client to work with new API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "sort-packages": true,
         "preferred-install": "dist",
         "allow-plugins": {
-            "infection/extension-installer": true
+            "infection/extension-installer": true,
+            "php-http/discovery": true
         }
     },
     "minimum-stability": "dev",
@@ -35,7 +36,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "beluga-php/docker-php-api": "7.1.41.x-dev",
+        "beluga-php/docker-php-api": "7.1.41.2",
         "nyholm/psr7": "^1.3",
         "php-http/client-common": "^2.3",
         "php-http/socket-client": "^2.0",

--- a/src/Docker.php
+++ b/src/Docker.php
@@ -24,25 +24,25 @@ class Docker extends Client
     /**
      * {@inheritdoc}
      */
-    public function containerAttach(string $id, array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
+    public function containerAttach(string $id, array $queryParameters = [], string $fetch = self::FETCH_OBJECT, array $accept = [])
     {
-        return $this->executeEndpoint(new ContainerAttach($id, $queryParameters), $fetch);
+        return $this->executeEndpoint(new ContainerAttach($id, $queryParameters, $accept), $fetch);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function containerAttachWebsocket(string $id, array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
+    public function containerAttachWebsocket(string $id, array $queryParameters = [], string $fetch = self::FETCH_OBJECT, array $accept = [])
     {
-        return $this->executeEndpoint(new ContainerAttachWebsocket($id, $queryParameters), $fetch);
+        return $this->executeEndpoint(new ContainerAttachWebsocket($id, $queryParameters, $accept), $fetch);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function containerLogs(string $id, array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
+    public function containerLogs(string $id, array $queryParameters = [], string $fetch = self::FETCH_OBJECT, array $accept = [])
     {
-        return $this->executeEndpoint(new ContainerLogs($id, $queryParameters), $fetch);
+        return $this->executeEndpoint(new ContainerLogs($id, $queryParameters, $accept), $fetch);
     }
 
     /**
@@ -72,13 +72,13 @@ class Docker extends Client
     /**
      * {@inheritdoc}
      */
-    public function imagePush(string $name, array $queryParameters = [], array $headerParameters = [], string $fetch = self::FETCH_OBJECT)
+    public function imagePush(string $name, array $queryParameters = [], array $headerParameters = [], string $fetch = self::FETCH_OBJECT, array $accept = [])
     {
         if (isset($headerParameters['X-Registry-Auth']) && $headerParameters['X-Registry-Auth'] instanceof AuthConfig) {
             $headerParameters['X-Registry-Auth'] = \base64_encode($this->serializer->serialize($headerParameters['X-Registry-Auth'], 'json'));
         }
 
-        return $this->executeEndpoint(new ImagePush($name, $queryParameters, $headerParameters), $fetch);
+        return $this->executeEndpoint(new ImagePush($name, $queryParameters, $headerParameters, $accept), $fetch);
     }
 
     /**

--- a/src/DockerClientFactory.php
+++ b/src/DockerClientFactory.php
@@ -8,6 +8,7 @@ use Http\Client\Common\Plugin\AddHostPlugin;
 use Http\Client\Common\Plugin\AddPathPlugin;
 use Http\Client\Common\Plugin\ContentLengthPlugin;
 use Http\Client\Common\Plugin\DecoderPlugin;
+use Http\Client\Common\Plugin\HeaderDefaultsPlugin;
 use Http\Client\Common\PluginClientFactory;
 use Http\Client\Socket\Client;
 use Http\Discovery\UriFactoryDiscovery;
@@ -35,6 +36,9 @@ final class DockerClientFactory
                 new DecoderPlugin(),
                 new AddPathPlugin($uriFactory->createUri('/v1.41')),
                 new AddHostPlugin($uriFactory->createUri($host)),
+                new HeaderDefaultsPlugin([
+                    'host' => \parse_url($host, \PHP_URL_HOST),
+                ]),
             ],
             [
                 'client_name' => 'docker-client',

--- a/src/Endpoint/ContainerAttach.php
+++ b/src/Endpoint/ContainerAttach.php
@@ -8,18 +8,18 @@ use Docker\API\Endpoint\ContainerAttach as BaseEndpoint;
 use Docker\Stream\DockerRawStream;
 use Nyholm\Psr7\Stream;
 use Symfony\Component\Serializer\SerializerInterface;
+use \Psr\Http\Message\ResponseInterface;
 
 class ContainerAttach extends BaseEndpoint
 {
-    protected function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null)
-    {
-        if (200 === $status && DockerRawStream::HEADER === $contentType) {
-            $stream = Stream::create($body);
+    protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = NULL)    {
+        if (200 === $response->getStatusCode() && DockerRawStream::HEADER === $contentType) {
+            $stream = Stream::create($response->getBody());
             $stream->rewind();
 
             return new DockerRawStream($stream);
         }
 
-        return parent::transformResponseBody($body, $status, $serializer, $contentType);
+        return parent::transformResponseBody($response, $serializer, $contentType);
     }
 }

--- a/src/Endpoint/ContainerAttachWebsocket.php
+++ b/src/Endpoint/ContainerAttachWebsocket.php
@@ -9,6 +9,7 @@ use Docker\Stream\AttachWebsocketStream;
 use Docker\Stream\DockerRawStream;
 use Nyholm\Psr7\Stream;
 use Symfony\Component\Serializer\SerializerInterface;
+use \Psr\Http\Message\ResponseInterface;
 
 class ContainerAttachWebsocket extends BaseEndpoint
 {
@@ -27,15 +28,14 @@ class ContainerAttachWebsocket extends BaseEndpoint
         );
     }
 
-    protected function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null)
-    {
-        if (200 === $status && DockerRawStream::HEADER === $contentType) {
-            $stream = Stream::create($body);
+    protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = NULL)    {
+        if (200 === $response->getStatusCode() && DockerRawStream::HEADER === $contentType) {
+            $stream = Stream::create($response->getBody());
             $stream->rewind();
 
             return new AttachWebsocketStream($stream);
         }
 
-        return parent::transformResponseBody($body, $status, $serializer, $contentType);
+        return parent::transformResponseBody($response, $serializer, $contentType);
     }
 }

--- a/src/Endpoint/ContainerLogs.php
+++ b/src/Endpoint/ContainerLogs.php
@@ -8,18 +8,18 @@ use Docker\API\Endpoint\ContainerLogs as BaseEndpoint;
 use Docker\Stream\DockerRawStream;
 use Nyholm\Psr7\Stream;
 use Symfony\Component\Serializer\SerializerInterface;
+use \Psr\Http\Message\ResponseInterface;
 
 class ContainerLogs extends BaseEndpoint
 {
-    protected function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null)
-    {
-        if (200 === $status && DockerRawStream::HEADER === $contentType) {
-            $stream = Stream::create($body);
+    protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = NULL)    {
+        if (200 === $response->getStatusCode() && DockerRawStream::HEADER === $contentType) {
+            $stream = Stream::create($response->getBody());
             $stream->rewind();
 
             return new DockerRawStream($stream);
         }
 
-        return parent::transformResponseBody($body, $status, $serializer, $contentType);
+        return parent::transformResponseBody($response, $serializer, $contentType);
     }
 }

--- a/src/Endpoint/ExecStart.php
+++ b/src/Endpoint/ExecStart.php
@@ -8,18 +8,18 @@ use Docker\API\Endpoint\ExecStart as BaseEndpoint;
 use Docker\Stream\DockerRawStream;
 use Nyholm\Psr7\Stream;
 use Symfony\Component\Serializer\SerializerInterface;
+use \Psr\Http\Message\ResponseInterface;
 
 class ExecStart extends BaseEndpoint
 {
-    protected function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null)
-    {
-        if (200 === $status && DockerRawStream::HEADER === $contentType) {
-            $stream = Stream::create($body);
+    protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = NULL)    {
+        if (200 === $response->getStatusCode() && DockerRawStream::HEADER === $contentType) {
+            $stream = Stream::create($response->getBody());
             $stream->rewind();
 
             return new DockerRawStream($stream);
         }
 
-        return parent::transformResponseBody($body, $status, $serializer, $contentType);
+        return parent::transformResponseBody($response, $serializer, $contentType);
     }
 }

--- a/src/Endpoint/ImageBuild.php
+++ b/src/Endpoint/ImageBuild.php
@@ -9,6 +9,7 @@ use Docker\Stream\BuildStream;
 use Docker\Stream\TarStream;
 use Nyholm\Psr7\Stream;
 use Symfony\Component\Serializer\SerializerInterface;
+use \Psr\Http\Message\ResponseInterface;
 
 class ImageBuild extends BaseEndpoint
 {
@@ -23,15 +24,14 @@ class ImageBuild extends BaseEndpoint
         return [['Content-Type' => ['application/octet-stream']], $body];
     }
 
-    protected function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null)
-    {
-        if (200 === $status) {
-            $stream = Stream::create($body);
+    protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = NULL)    {
+        if (200 === $response->getStatusCode()) {
+            $stream = Stream::create($response->getBody());
             $stream->rewind();
 
             return new BuildStream($stream, $serializer);
         }
 
-        return parent::transformResponseBody($body, $status, $serializer, $contentType);
+        return parent::transformResponseBody($response, $serializer, $contentType);
     }
 }

--- a/src/Endpoint/ImageCreate.php
+++ b/src/Endpoint/ImageCreate.php
@@ -8,18 +8,18 @@ use Docker\API\Endpoint\ImageCreate as BaseEndpoint;
 use Docker\Stream\CreateImageStream;
 use Nyholm\Psr7\Stream;
 use Symfony\Component\Serializer\SerializerInterface;
+use \Psr\Http\Message\ResponseInterface;
 
 class ImageCreate extends BaseEndpoint
 {
-    protected function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null)
-    {
-        if (200 === $status) {
-            $stream = Stream::create($body);
+    protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = NULL)    {
+        if (200 === $response->getStatusCode()) {
+            $stream = Stream::create($response->getBody());
             $stream->rewind();
 
             return new CreateImageStream($stream, $serializer);
         }
 
-        return parent::transformResponseBody($body, $status, $serializer, $contentType);
+        return parent::transformResponseBody($response, $serializer, $contentType);
     }
 }

--- a/src/Endpoint/ImagePush.php
+++ b/src/Endpoint/ImagePush.php
@@ -8,6 +8,7 @@ use Docker\API\Endpoint\ImagePush as BaseEndpoint;
 use Docker\Stream\PushStream;
 use Nyholm\Psr7\Stream;
 use Symfony\Component\Serializer\SerializerInterface;
+use \Psr\Http\Message\ResponseInterface;
 
 class ImagePush extends BaseEndpoint
 {
@@ -16,15 +17,14 @@ class ImagePush extends BaseEndpoint
         return \str_replace(['{name}'], [\urlencode($this->name)], '/images/{name}/push');
     }
 
-    protected function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null)
-    {
-        if (200 === $status) {
-            $stream = Stream::create($body);
+    protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = NULL)    {
+        if (200 === $response->getStatusCode()) {
+            $stream = Stream::create($response->getBody());
             $stream->rewind();
 
             return new PushStream($stream, $serializer);
         }
 
-        return parent::transformResponseBody($body, $status, $serializer, $contentType);
+        return parent::transformResponseBody($response, $serializer, $contentType);
     }
 }

--- a/src/Endpoint/SystemEvents.php
+++ b/src/Endpoint/SystemEvents.php
@@ -8,18 +8,18 @@ use Docker\API\Endpoint\SystemEvents as BaseEndpoint;
 use Docker\Stream\EventStream;
 use Nyholm\Psr7\Stream;
 use Symfony\Component\Serializer\SerializerInterface;
+use \Psr\Http\Message\ResponseInterface;
 
 class SystemEvents extends BaseEndpoint
 {
-    protected function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null)
-    {
-        if (200 === $status) {
-            $stream = Stream::create($body);
+    protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = NULL)    {
+        if (200 === $response->getStatusCode()) {
+            $stream = Stream::create($response->getBody());
             $stream->rewind();
 
             return new EventStream($stream, $serializer);
         }
 
-        return parent::transformResponseBody($body, $status, $serializer, $contentType);
+        return parent::transformResponseBody($response, $serializer, $contentType);
     }
 }


### PR DESCRIPTION
To get everything working together I had to:

- Add the host header to requests as it's required to communicate with the docker API
- Update the endpoints to consume the new method props
- Update composer to use the new API version

I've tested this version against my production code, and it passed all tests (although we don't have coverage of the full API).

Some refactoring of our codebase was necessary (but minimal) such as:

`setEndpointsConfig()` now takes an array rather than array object
`execStart()` now returns a steamInterface so we refactored to read that instead of onStdout/onStderr