### PR TITLE
Avoid Jane-php deprecations.

### DIFF
--- a/src/Docker.php
+++ b/src/Docker.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Docker;
 
 use Docker\API\Client;
+use Docker\API\Endpoint\SystemInfo;
 use Docker\API\Exception\BadRequestException;
 use Docker\API\Model\AuthConfig;
 use Docker\API\Model\ExecIdStartPostBody;
-use Docker\API\Runtime\Client\Client as RuntimeClient;
 use Docker\Endpoint\ContainerAttach;
 use Docker\Endpoint\ContainerAttachWebsocket;
 use Docker\Endpoint\ContainerLogs;
@@ -94,7 +94,7 @@ class Docker extends Client
         }
 
         $client = parent::create($httpClient, $additionalPlugins, $additionalNormalizers);
-        $testClient = $client->systemInfo(RuntimeClient::FETCH_RESPONSE)->getBody()->getContents();
+        $testClient = $client->executeRawEndpoint(new SystemInfo())->getBody()->getContents();
         $jsonObj = json_decode($testClient);
 
         if ($jsonObj !== null) {


### PR DESCRIPTION
When I run `Docker\Docker::create()` I get 
```
ERROR: Since jane-php/open-api-common 7.3: Using Docker\API\Runtime\Client\Client::Docker\API\Runtime\Client\Client::executeEndpoint method with $fetch parameter equals to response is deprecated, use Docker\API\Runtime\Client\Client::executeRawEndpoint instead. 
in /home/basin/vendor/symfony/deprecation-contracts/function.php:25
```
Because of the code that checks for bad messages when the client is created.

This change follows the indication of the deprecation message to use executeRawEndpoint. Please review