### PR TITLE
Add conflict with non-compatible versions of nikic/php-parser.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,12 +46,13 @@
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^9.5",
-        "psy/psysh": "^0.11",
+        "psy/psysh": "^0.12",
         "roave/security-advisories": "dev-latest"
     },
     "conflict": {
         "docker-php/docker-php": "*",
-        "php-http/message": "<1.15"
+        "php-http/message": "<1.15",
+        "nikic/php-parser": "<4.13"
     },
     "scripts": {
         "php-cs-fixer": "vendor/bin/php-cs-fixer fix --dry-run --verbose --diff",


### PR DESCRIPTION
Bump psy/psysh to allow for nikic/php-parser v5.

Following up on the error from github actions
https://github.com/beluga-php/docker-php/actions/runs/7960004992/job/21769598590

I arrived with a google search to a similar error
https://github.com/sebastianbergmann/phpcov/issues/113

One of the solutions was to bump nikic/php-parser so let's just do that https://github.com/sebastianbergmann/php-code-coverage/commit/347a87a7f8b2b78e87200d7de0058dd4ae05f76d

it is strange that "prefer-lowest" is picking php-parser 4.10 since the requirements are at least for 4.18 :shrug: 
This is the output of `composer why nikic/php-parser`
```
phpunit/php-code-coverage 9.2.30     requires  nikic/php-parser (^4.18 || ^5.0) 
psy/psysh                 v0.11.22   requires  nikic/php-parser (^4.0 || ^3.1)  
sebastian/complexity      2.0.3      requires  nikic/php-parser (^4.18 || ^5.0) 
sebastian/lines-of-code   1.0.4      requires  nikic/php-parser (^4.18 || ^5.0) 
```

For this reason I'm also bumping psysh, so the v5 of the parser can be installed.