### PR TITLE
Update symfony packages to ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,9 +37,9 @@
         "php-http/discovery": "^1.19",
         "plesk/socket-client": "^2.1",
         "psr/http-message": "^2.0",
-        "symfony/filesystem": "^6.3",
-        "symfony/process": "^6.3",
-        "symfony/serializer": "^6.3"
+        "symfony/filesystem": "^7.0",
+        "symfony/process": "^7.0",
+        "symfony/serializer": "^7.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.8",


### PR DESCRIPTION
Update to new symfony packages. They mention in their release notes that they have no significant changes. 

We could also  do a `"^6.0|^7.0"` if you prefer?