### PR TITLE
feat: Docker api client version env variable

### DIFF
--- a/src/DockerClientFactory.php
+++ b/src/DockerClientFactory.php
@@ -28,13 +28,14 @@ final class DockerClientFactory
         $host = preg_match('/unix:\/\//', $config['remote_socket']) ? 'http://localhost' : $config['remote_socket'];
 
         $pluginClientFactory ??= new PluginClientFactory();
+        $dockerClientVersion = getenv('DOCKER_API_VERSION') ?? 'v1.43';
 
         return $pluginClientFactory->createClient(
             $socketClient,
             [
                 new ContentLengthPlugin(),
                 new DecoderPlugin(),
-                new AddPathPlugin($uriFactory->createUri('/v1.43')),
+                new AddPathPlugin($uriFactory->createUri('/' . ltrim($dockerClientVersion))),
                 new AddHostPlugin($uriFactory->createUri($host)),
                 new HeaderDefaultsPlugin([
                     'host' => parse_url($host, \PHP_URL_HOST),

--- a/src/DockerClientFactory.php
+++ b/src/DockerClientFactory.php
@@ -28,7 +28,7 @@ final class DockerClientFactory
         $host = preg_match('/unix:\/\//', $config['remote_socket']) ? 'http://localhost' : $config['remote_socket'];
 
         $pluginClientFactory ??= new PluginClientFactory();
-        $dockerClientVersion = getenv('DOCKER_API_VERSION') ?? 'v1.43';
+        $dockerClientVersion = getenv('DOCKER_API_VERSION') ? getenv('DOCKER_API_VERSION') : 'v1.43';
 
         return $pluginClientFactory->createClient(
             $socketClient,

--- a/src/DockerClientFactory.php
+++ b/src/DockerClientFactory.php
@@ -28,7 +28,7 @@ final class DockerClientFactory
         $host = preg_match('/unix:\/\//', $config['remote_socket']) ? 'http://localhost' : $config['remote_socket'];
 
         $pluginClientFactory ??= new PluginClientFactory();
-        $dockerClientVersion = getenv('DOCKER_API_VERSION') ? getenv('DOCKER_API_VERSION') : 'v1.43';
+        $dockerClientVersion = getenv('DOCKER_API_VERSION') ? getenv('DOCKER_API_VERSION') : 'v1.45';
 
         return $pluginClientFactory->createClient(
             $socketClient,


### PR DESCRIPTION
Hello? 

I'm user of testcontainers which is not working properly due to docker api version requirements.
The error was:
```
client version 1.43 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version
```

Then I solved this problem by introducing new ENV variable `DOCKER_API_VERSION` and its default value remains as same as before (v1.43).

Now, People who has newer version of Docker API able to use beluga-php/docker-php by 

```
DOCKER_API_VERSION=v1.52 /usr/bin/php ...
```
